### PR TITLE
Fix TPE config file

### DIFF
--- a/test/benchmark/tpe.yaml
+++ b/test/benchmark/tpe.yaml
@@ -1,5 +1,4 @@
-algorithms:
-  TPE: null
+algorithms: TPE
     # NOTE: Add arguments here if necessary
 
 database:


### PR DESCRIPTION
The algorithm factory expects a dictionary under the name of an algorithm. `null` makes it fail, but setting only the algorithm name is fine.